### PR TITLE
Enable SSL Support for remote PuppetDB query

### DIFF
--- a/puppetdb/core.py
+++ b/puppetdb/core.py
@@ -30,7 +30,7 @@ class AuthException(BaseException):
 
 class PuppetDBClient(object):
     def __init__(self, host='localhost', port=8080, api_version='v2',
-        use_ssl=False):
+        use_ssl=False, verify=True, cert=list()):
         self._host = host
         self._port = port
         self._api_version = api_version
@@ -42,24 +42,26 @@ class PuppetDBClient(object):
             'v2': v2,
         }
         self._api = apis[api_version]
+        self._verify = verify
+        self._cert = cert
         self._api_url = '{0}://{1}:{2}/{3}'.format(ssl[use_ssl], self._host,
             self._port, api_version)
 
     def get_nodes(self):
-        return self._api.nodes.get_nodes(self._api_url)
+        return self._api.nodes.get_nodes(self._api_url, self._verify, self._cert)
 
     def get_node(self, node_name=None):
-        return self._api.nodes.get_node(self._api_url, node_name)
+        return self._api.nodes.get_node(self._api_url, node_name, self._verify, self._cert)
 
     def get_node_facts(self, node_name=None):
-        return self._api.nodes.get_node_facts(self._api_url, node_name)
+        return self._api.nodes.get_node_facts(self._api_url, node_name, self._verify, self._cert)
 
     def get_node_fact_by_name(self, node_name=None, fact_name=None):
-        return self._api.nodes.get_node_fact_by_name(self._api_url, node_name, fact_name)
+        return self._api.nodes.get_node_fact_by_name(self._api_url, node_name, fact_name, self._verify, self._cert)
 
     def get_node_resources(self, node_name=None):
-        return self._api.nodes.get_node_resources(self._api_url, node_name)
+        return self._api.nodes.get_node_resources(self._api_url, node_name, self._verify, self._cert)
 
     def get_node_resource_by_type(self, node_name=None, type_name=None):
         return self._api.nodes.get_node_resource_by_type(self._api_url, node_name,
-            type_name)
+            type_name, self._verify, self._cert)

--- a/puppetdb/utils.py
+++ b/puppetdb/utils.py
@@ -27,7 +27,7 @@ except ImportError:
     import json
 
 def api_request(api_base_url='http://localhost:8080/', path='', method='get',
-    data=None, params={}):
+    data=None, params={}, verify=True, cert=list()):
     """
     Wrapper function for requests
 
@@ -36,6 +36,8 @@ def api_request(api_base_url='http://localhost:8080/', path='', method='get',
     :param method: HTTP method
     :param data: Data for post (ignored for GETs)
     :param params: Dict of key, value query params
+    :param verify: True/False/CA_File_Name to perform SSL Verification of CA Chain
+    :param cert: list of cert and key to use for client authentication
 
     """
     method = method.lower()
@@ -52,11 +54,11 @@ def api_request(api_base_url='http://localhost:8080/', path='', method='get',
     if params:
         path += '?{0}'.format(urllib.urlencode(params))
     url = '{0}{1}'.format(api_base_url, path)
-    resp = methods[method](url, data=json.dumps(data), headers=headers)
+    resp = methods[method](url, data=json.dumps(data), headers=headers, verify=verify, cert=cert)
     return resp
 
-def _make_api_request(api_url=None, path=None):
-    resp = api_request(api_url, path)
+def _make_api_request(api_url=None, path=None, verify=False, cert=list()):
+    resp = api_request(api_url, path, verify=verify, cert=cert)
     data = json.loads(resp.content)
     return data
 

--- a/puppetdb/v2/nodes.py
+++ b/puppetdb/v2/nodes.py
@@ -22,16 +22,16 @@ from puppetdb import utils
 
 API_VERSION = 'v2'
 
-def get_nodes(api_url=None):
+def get_nodes(api_url=None, verify=False, cert=list()):
     """
     Returns info for all Nodes
 
     :param api_url: Base PuppetDB API url
 
     """
-    return utils._make_api_request(api_url, '/nodes')
+    return utils._make_api_request(api_url, '/nodes', verify=False, cert=list())
 
-def get_node(api_url=None, node_name=None):
+def get_node(api_url=None, node_name=None, verify=False, cert=list()):
     """
     Returns info for a Node
 
@@ -39,9 +39,9 @@ def get_node(api_url=None, node_name=None):
     :param node_name: Name of node
 
     """
-    return utils._make_api_request(api_url, '/nodes/{0}'.format(node_name))
+    return utils._make_api_request(api_url, '/nodes/{0}'.format(node_name), verify=False, cert=list())
 
-def get_node_facts(api_url=None, node_name=None):
+def get_node_facts(api_url=None, node_name=None, verify=False, cert=list()):
     """
     Returns facts for a Node
 
@@ -49,9 +49,9 @@ def get_node_facts(api_url=None, node_name=None):
     :param node_name: Name of node
 
     """
-    return utils._make_api_request(api_url, '/nodes/{0}/facts'.format(node_name))
+    return utils._make_api_request(api_url, '/nodes/{0}/facts'.format(node_name), verify=False, cert=list())
 
-def get_node_fact_by_name(api_url=None, node_name=None, fact_name=None):
+def get_node_fact_by_name(api_url=None, node_name=None, fact_name=None, verify=False, cert=list()):
     """
     Returns specified fact for a Node
 
@@ -61,9 +61,9 @@ def get_node_fact_by_name(api_url=None, node_name=None, fact_name=None):
 
     """
     return utils._make_api_request(api_url, '/nodes/{0}/facts/{1}'.format(node_name,
-        fact_name))
+        fact_name), verify=False, cert=list())
 
-def get_node_resources(api_url=None, node_name=None):
+def get_node_resources(api_url=None, node_name=None, verify=False, cert=list()):
     """
     Returns resources for a Node
 
@@ -71,10 +71,10 @@ def get_node_resources(api_url=None, node_name=None):
     :param node_name: Name of node
 
     """
-    return utils._make_api_request(api_url, '/nodes/{0}/resources'.format(node_name))
+    return utils._make_api_request(api_url, '/nodes/{0}/resources'.format(node_name), verify=False, cert=list())
 
 def get_node_resource_by_type(api_url=None, node_name=None,
-    type_name=None):
+    type_name=None, verify=False, cert=list()):
     """
     Returns specified resource for a Node
 
@@ -84,13 +84,13 @@ def get_node_resource_by_type(api_url=None, node_name=None,
 
     """
     return utils._make_api_request(api_url, '/nodes/{0}/resources/{1}'.format(node_name,
-        type_name))
+        type_name), verify=False, cert=list())
 
-def get_facts(api_url=None, query={}):
+def get_facts(api_url=None, query={}, verify=False, cert=list()):
     """
     Returns info for all Nodes
 
     :param api_url: Base PuppetDB API url
 
     """
-    return utils._make_api_request(api_url, '/nodes')
+    return utils._make_api_request(api_url, '/nodes', verify=False, cert=list())

--- a/puppetdb/v2/nodes.py
+++ b/puppetdb/v2/nodes.py
@@ -29,7 +29,7 @@ def get_nodes(api_url=None, verify=False, cert=list()):
     :param api_url: Base PuppetDB API url
 
     """
-    return utils._make_api_request(api_url, '/nodes', verify=False, cert=list())
+    return utils._make_api_request(api_url, '/nodes', verify, cert)
 
 def get_node(api_url=None, node_name=None, verify=False, cert=list()):
     """
@@ -39,7 +39,7 @@ def get_node(api_url=None, node_name=None, verify=False, cert=list()):
     :param node_name: Name of node
 
     """
-    return utils._make_api_request(api_url, '/nodes/{0}'.format(node_name), verify=False, cert=list())
+    return utils._make_api_request(api_url, '/nodes/{0}'.format(node_name), verify, cert)
 
 def get_node_facts(api_url=None, node_name=None, verify=False, cert=list()):
     """
@@ -49,7 +49,7 @@ def get_node_facts(api_url=None, node_name=None, verify=False, cert=list()):
     :param node_name: Name of node
 
     """
-    return utils._make_api_request(api_url, '/nodes/{0}/facts'.format(node_name), verify=False, cert=list())
+    return utils._make_api_request(api_url, '/nodes/{0}/facts'.format(node_name), verify, cert)
 
 def get_node_fact_by_name(api_url=None, node_name=None, fact_name=None, verify=False, cert=list()):
     """
@@ -61,7 +61,7 @@ def get_node_fact_by_name(api_url=None, node_name=None, fact_name=None, verify=F
 
     """
     return utils._make_api_request(api_url, '/nodes/{0}/facts/{1}'.format(node_name,
-        fact_name), verify=False, cert=list())
+        fact_name), verify, cert)
 
 def get_node_resources(api_url=None, node_name=None, verify=False, cert=list()):
     """
@@ -71,7 +71,7 @@ def get_node_resources(api_url=None, node_name=None, verify=False, cert=list()):
     :param node_name: Name of node
 
     """
-    return utils._make_api_request(api_url, '/nodes/{0}/resources'.format(node_name), verify=False, cert=list())
+    return utils._make_api_request(api_url, '/nodes/{0}/resources'.format(node_name), verify, cert)
 
 def get_node_resource_by_type(api_url=None, node_name=None,
     type_name=None, verify=False, cert=list()):
@@ -84,7 +84,7 @@ def get_node_resource_by_type(api_url=None, node_name=None,
 
     """
     return utils._make_api_request(api_url, '/nodes/{0}/resources/{1}'.format(node_name,
-        type_name), verify=False, cert=list())
+        type_name), verify, cert)
 
 def get_facts(api_url=None, query={}, verify=False, cert=list()):
     """
@@ -93,4 +93,4 @@ def get_facts(api_url=None, query={}, verify=False, cert=list()):
     :param api_url: Base PuppetDB API url
 
     """
-    return utils._make_api_request(api_url, '/nodes', verify=False, cert=list())
+    return utils._make_api_request(api_url, '/nodes', verify, cert)

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,15 @@ Note: this currently only supports PuppetDB API version 2
 
 ```
 
+For connections to a remote PuppetDB host, you have to authenticate using SSL and client certificates
+
+```
+>>> from puppetdb import PuppetDBClient
+>>> c = PuppetDBClient(host="puppetdb.example.com",port=8081,use_ssl=True,verify='/var/lib/puppet/ssl/certs/ca.pem',cert=('/var/lib/puppet/ssl/certs/puppet.travian.info.pem','/var/lib/puppet/ssl/private_keys/puppet.travian.info.pem'))
+...
+```
+
+
 # ToDo
 
 * Facts Endpoint

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='support@arcus.io',
     keywords=['puppet', 'puppetdb'],
     license='Apache 2.0',
-    packages=['puppetdb'],
+    packages=['puppetdb','puppetdb/v2'],
     install_requires = [ 'requests' ],
     test_suite='tests.all_tests',
     classifiers=[


### PR DESCRIPTION
Hello, 
I used your module to query puppetdb. However it seems it did not work with SSL out of the box (e.g. when puppetdb  is queried from another node). Here PupppetCA integration is needed. 

I added this support and for me it works now. Maybe it is worth an upstream merge.

P.s. I also added "pupppetdb/v2" to the packages list, so that "pypi2rpm" and "python setup.py build" works. 
Docu is added too.

Regards, 
Robert
